### PR TITLE
Add cd command for compiling examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ Inside ``pynes/examples`` you'll find a set of examples. Compile them with:
 
 .. code-block:: shell
 
+  cd pynes/examples/
   pynes py helloworld.py -o helloworld.nes
 
 Now you can open helloworld.nes

--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,7 @@ Inside ``pynes/examples`` you'll find a set of examples. Compile them with:
 
 .. code-block:: shell
 
-  cd pynes/examples/
-  pynes py helloworld.py -o helloworld.nes
+  pynes py pynes/examples/helloworld.py -o helloworld.nes
 
 Now you can open helloworld.nes
 


### PR DESCRIPTION
The change directory command was included for 'cd pyNES' so I figured I'd add it to the compile step for consistency.