### PR TITLE
docs: fix simple typo, statments -> statements

### DIFF
--- a/pynes/compiler.py
+++ b/pynes/compiler.py
@@ -348,7 +348,7 @@ def semantic(ast, iNES=False, cart=None):
         cart = Cartridge()
     labels = get_labels(ast)
     address = 0
-    # translate statments to opcode
+    # translate statements to opcode
     for leaf in ast:
         if leaf['type'] == 'S_RS':
             labels[leaf['children'][0]['value']] = cart.rs


### PR DESCRIPTION
There is a small typo in pynes/compiler.py.

Should read `statements` rather than `statments`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md